### PR TITLE
Smooth graphics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pixi-graph",
+  "name": "pixi-graph-fork",
   "version": "1.3.0",
   "description": "Graph visualization library using PIXI.js and Graphology",
   "keywords": [
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "author": "Jan Zak <zj@zakjan.cz>",
-  "repository": "github:zakjan/pixi-graph",
+  "repository": "github:AlexRoar/pixi-graph",
   "main": "dist/pixi-graph.cjs.js",
   "module": "dist/pixi-graph.esm.js",
   "browser": "dist/pixi-graph.umd.min.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pixi-graph-fork",
+  "name": "pixi-graph",
   "version": "1.3.0",
   "description": "Graph visualization library using PIXI.js and Graphology",
   "keywords": [
@@ -8,7 +8,7 @@
   ],
   "license": "MIT",
   "author": "Jan Zak <zj@zakjan.cz>",
-  "repository": "github:AlexRoar/pixi-graph",
+  "repository": "github:zakjan/pixi-graph",
   "main": "dist/pixi-graph.cjs.js",
   "module": "dist/pixi-graph.esm.js",
   "browser": "dist/pixi-graph.umd.min.js",
@@ -25,7 +25,7 @@
     "@pixi/constants": "^6.0.2",
     "@pixi/core": "^6.0.2",
     "@pixi/display": "^6.0.2",
-    "@pixi/graphics-smooth": "^0.0.13",
+    "@pixi/graphics": "^6.0.2",
     "@pixi/interaction": "^6.0.2",
     "@pixi/loaders": "^6.0.2",
     "@pixi/math": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@pixi/constants": "^6.0.2",
     "@pixi/core": "^6.0.2",
     "@pixi/display": "^6.0.2",
-    "@pixi/graphics": "^6.0.2",
+    "@pixi/graphics-smooth": "^0.0.13",
     "@pixi/interaction": "^6.0.2",
     "@pixi/loaders": "^6.0.2",
     "@pixi/math": "^6.0.2",

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -179,6 +179,7 @@ export class PixiGraph<NodeAttributes extends BaseNodeAttributes = BaseNodeAttri
 
     // preload resources
     if (this.resources) {
+      // @ts-ignore
       this.app.loader.add(this.resources);
     }
     this.app.loader.load(() => {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -17,6 +17,7 @@ import { BaseNodeAttributes, BaseEdgeAttributes } from './attributes';
 import { TextureCache } from './texture-cache';
 import { PixiNode } from './node';
 import { PixiEdge } from './edge';
+import {LINE_SCALE_MODE, settings} from '@pixi/graphics-smooth';
 
 Application.registerPlugin(TickerPlugin);
 Application.registerPlugin(AppLoaderPlugin);
@@ -128,6 +129,8 @@ export class PixiGraph<NodeAttributes extends BaseNodeAttributes = BaseNodeAttri
     if (!(this.container instanceof HTMLElement)) {
       throw new Error('container should be a HTMLElement');
     }
+
+    settings.LINE_SCALE_MODE = LINE_SCALE_MODE.NORMAL
 
     // create PIXI application
     this.app = new Application({

--- a/src/renderers/node.ts
+++ b/src/renderers/node.ts
@@ -1,7 +1,7 @@
 import { Container } from '@pixi/display';
 import { Circle } from '@pixi/math';
 import { Sprite } from '@pixi/sprite';
-import { Graphics } from '@pixi/graphics';
+import { SmoothGraphics as Graphics } from '@pixi/graphics-smooth';
 import '@pixi/mixin-get-child-by-name';
 import { colorToPixi } from '../utils/color';
 import { NodeStyle } from '../utils/style';

--- a/src/renderers/node.ts
+++ b/src/renderers/node.ts
@@ -1,7 +1,7 @@
 import { Container } from '@pixi/display';
 import { Circle } from '@pixi/math';
 import { Sprite } from '@pixi/sprite';
-import { SmoothGraphics as Graphics } from '@pixi/graphics-smooth';
+import { SmoothGraphics as Graphics} from '@pixi/graphics-smooth';
 import '@pixi/mixin-get-child-by-name';
 import { colorToPixi } from '../utils/color';
 import { NodeStyle } from '../utils/style';
@@ -44,7 +44,7 @@ export function updateNodeStyle(nodeGfx: Container, nodeStyle: NodeStyle, textur
   const nodeCircleTextureKey = [NODE_CIRCLE, nodeStyle.size].join(DELIMETER);
   const nodeCircleTexture = textureCache.get(nodeCircleTextureKey, () => {
     const graphics = new Graphics();
-    graphics.beginFill(WHITE);
+    graphics.beginFill(WHITE, 1.0, true);
     graphics.drawCircle(nodeStyle.size, nodeStyle.size, nodeStyle.size);
     return graphics;
   });


### PR DESCRIPTION
Graph nodes look too crisp and not antialiased.

Literally added two lines – replaced pixi/graphics with [pixi/graphics-smooth](https://www.npmjs.com/package/@pixi/graphics-smooth) and added smoothing param to fills.

It's possible to add smoothing param to graph settings